### PR TITLE
Removed the System.Net.Http reference

### DIFF
--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -117,7 +117,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="UIAutomationProvider" />
     <Reference Include="unvell.ReoGrid, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
Was not used anywhere. And its no longer in .Net farmework by default